### PR TITLE
chore: repo hygiene (bump deprecated Actions + fix CONTRIBUTING)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,38 @@
 # SPSUpdate - Contributing
 
-If you'd like to contribute to this project, please review the [Contribution Guidelines](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md).
+Thanks for your interest in improving SPSUpdate! Contributions of all kinds are welcome:
+bug reports, feature requests, documentation, and pull requests.
+
+## Before you start
+
+- Search the [existing issues](https://github.com/luigilink/SPSUpdate/issues) to avoid duplicates.
+- For questions and ideas, open a [discussion](https://github.com/luigilink/SPSUpdate/discussions).
+- Read the [wiki](https://github.com/luigilink/SPSUpdate/wiki) for usage, configuration, and the
+  [Release Process](https://github.com/luigilink/SPSUpdate/wiki/Release-Process).
+
+## Reporting bugs and requesting features
+
+Use the [issue templates](https://github.com/luigilink/SPSUpdate/issues/new/choose) (bug report,
+feature request, documentation request, improvement request) and fill in as much detail as possible.
+
+## Pull requests
+
+1. Fork the repository and create a topic branch from `main`.
+2. Keep changes focused and commits atomic; reference the issue being resolved (e.g. `Closes #123`).
+3. Add or update the relevant Pester tests under `tests/` and make sure they pass locally:
+
+   ```powershell
+   Invoke-Pester -Path .\tests
+   Invoke-ScriptAnalyzer -Path .\src -Recurse -Settings .\PSScriptAnalyzerSettings.psd1
+   ```
+
+4. Add an entry to `CHANGELOG.md` describing what changed and how it affects users.
+5. Update the wiki pages under `wiki/` when behaviour, parameters, or configuration change.
+6. Open the pull request and complete the checklist in the PR template.
+
+## Coding conventions
+
+- Target Windows PowerShell 5.1+ and follow the existing SPS* toolkit style.
+- Shared logic lives in the `SPSUpdate.Common` module (one function per file under `Public/` or
+  `Private/`); the entry script `src/SPSUpdate.ps1` orchestrates the run.
+- The module `ModuleVersion` in `SPSUpdate.Common.psd1` is the single source of truth for the version.

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Pester
         shell: pwsh
@@ -47,7 +47,7 @@ jobs:
           Invoke-Pester -Configuration $config
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       # Checkout code
       - name: Checkout code
         id: checkout_code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       # Create a ZIP file with project name and tag version
       - name: Create ZIP file of src contents
         run: |
@@ -32,7 +32,7 @@ jobs:
       # Create Release with tag version
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{github.repository}}
           path: ${{github.repository}}
 
       - name: Checkout Wiki
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{github.repository}}.wiki
           path: ${{github.repository}}.wiki


### PR DESCRIPTION
Housekeeping only. No functional or packaging changes.

## Changes
- **CI:** bump `actions/checkout` and `actions/upload-artifact` to `v7`, `softprops/action-gh-release` to `v3` across all workflows. Only `uses:` version pins change.
- **Docs:** rewrite `.github/CONTRIBUTING.md` to point to this repository (wiki/issues/discussions) instead of `PowerShell/DscResources`.

## Validation
- YAML lint of all workflows passes.
- No CI run expected: `pester.yml` ignores `.github/**` and `CONTRIBUTING.md`; `release.yml` triggers on tags only.

Fixes #23
Fixes #24